### PR TITLE
Changes to gem initialization to work with rails3

### DIFF
--- a/default_value_for.gemspec
+++ b/default_value_for.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files = ['default_value_for.gemspec',
     'LICENSE.TXT', 'Rakefile', 'README.rdoc', 'test.rb',
     'init.rb',
-    'lib/default_value_for/core.rb',
+    'lib/default_value_for.rb',
     'lib/default_value_for/railtie.rb'
   ]
 end

--- a/init.rb
+++ b/init.rb
@@ -19,5 +19,4 @@
 # THE SOFTWARE.
 
 # Rails 2 initialization
-require "default_value_for/core"
-ActiveRecord::Base.extend(DefaultValueForPlugin::ClassMethods)
+ActiveRecord::Base.extend(DefaultValueFor::ClassMethods)

--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -1,0 +1,99 @@
+# Copyright (c) 2008, 2009, 2010, 2011 Phusion
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'default_value_for/railtie' if defined? Rails::Railtie
+
+module DefaultValueFor
+	class NormalValueContainer
+		def initialize(value)
+			@value = value
+		end
+
+		def evaluate(instance)
+			if @value.duplicable?
+				return @value.dup
+			else
+				return @value
+			end
+		end
+	end
+
+	class BlockValueContainer
+		def initialize(block)
+			@block = block
+		end
+
+		def evaluate(instance)
+			return @block.call(instance)
+		end
+	end
+
+	module ClassMethods
+		def default_value_for(attribute, value = nil, &block)
+			if !method_defined?(:initialize_with_defaults)
+				include(InstanceMethods)
+				alias_method_chain :initialize, :defaults
+				class_inheritable_accessor :_default_attribute_values
+				self._default_attribute_values = ActiveSupport::OrderedHash.new
+			end
+			if block_given?
+				container = BlockValueContainer.new(block)
+			else
+				container = NormalValueContainer.new(value)
+			end
+			_default_attribute_values[attribute.to_s] = container
+		end
+
+		def default_values(values)
+			values.each_pair do |key, value|
+				if value.kind_of? Proc
+					default_value_for(key, &value)
+				else
+					default_value_for(key, value)
+				end
+			end
+		end
+	end
+
+	module InstanceMethods
+		def initialize_with_defaults(attrs = nil)
+			initialize_without_defaults(attrs) do
+				if attrs
+					stringified_attrs = attrs.stringify_keys
+					safe_attrs = if respond_to? :sanitize_for_mass_assignment
+						sanitize_for_mass_assignment(stringified_attrs)
+					else
+						remove_attributes_protected_from_mass_assignment(stringified_attrs)
+					end
+					safe_attribute_names = safe_attrs.keys.map do |x|
+						x.to_s
+					end
+				end
+				self.class._default_attribute_values.each do |attribute, container|
+					if safe_attribute_names.nil? || !safe_attribute_names.any? { |attr_name| attr_name =~ /^#{attribute}($|\()/ }
+						__send__("#{attribute}=", container.evaluate(self))
+						changed_attributes.delete(attribute)
+					end
+				end
+				yield(self) if block_given?
+			end
+		end
+	end
+end

--- a/lib/default_value_for/railtie.rb
+++ b/lib/default_value_for/railtie.rb
@@ -19,14 +19,11 @@
 # THE SOFTWARE.
 
 # Rails 3 initialization
-module DefaultValueForPlugin
-	if defined? Rails::Railtie
-		class Railtie < Rails::Railtie
-			initializer 'default_value_for.insert_into_active_record' do
-				ActiveSupport.on_load :active_record do
-					require 'default_value_for/core'
-					ActiveRecord::Base.extend(DefaultValueForPlugin::ClassMethods)
-				end
+module DefaultValueFor
+	class Railtie < Rails::Railtie
+		initializer 'default_value_for.insert_into_active_record' do
+			ActiveSupport.on_load :active_record do
+				ActiveRecord::Base.extend(DefaultValueFor::ClassMethods)
 			end
 		end
 	end

--- a/test.rb
+++ b/test.rb
@@ -24,6 +24,7 @@ require 'active_record'
 require 'test/unit'
 require 'active_support/core_ext/logger'
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+require File.dirname(__FILE__) + '/lib/default_value_for'
 require File.dirname(__FILE__) + '/init'
 Dir.chdir(File.dirname(__FILE__))
 


### PR DESCRIPTION
Here's the pull request I talked about in issue #10. I've tested it with rails 2.3.10 and 3.0.5. The gem builds and the tests run as well.

I renamed the DefaultValueForPlugin module to DefaultValueFor which I thought honored the rubygems conventions better. If you don't want that I can revert it.
