### PR TITLE
Fixed a broken test

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -41,7 +41,11 @@ module DefaultValueFor
 		end
 
 		def evaluate(instance)
-			return @block.call(instance)
+			if @block.arity == 0
+				return @block.call
+			else
+				return @block.call(instance)
+			end
 		end
 	end
 

--- a/test.rb
+++ b/test.rb
@@ -224,7 +224,8 @@ class DefaultValuePluginTest < Test::Unit::TestCase
 	def test_default_values
 		define_model_class do
 			default_values :type => "normal",
-			               :number => lambda { 10 + 5 }
+											:number => lambda { 10 + 5 },
+											:timestamp => lambda {|_| Time.now }
 		end
 
 		object = TestClass.new


### PR DESCRIPTION
Test was breaking when default_values was given a lambda of arity 0. Added logic to check block's arity and only pass the instance if it is non-0.
