### PR TITLE
In Rails 3.1, ActiveRecord#initialize takes more than one argument

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -77,8 +77,8 @@ module DefaultValueFor
 	end
 
 	module InstanceMethods
-		def initialize_with_defaults(attrs = nil)
-			initialize_without_defaults(attrs) do
+		def initialize_with_defaults(attrs = nil, *args)
+			initialize_without_defaults(attrs, *args) do
 				if attrs
 					stringified_attrs = attrs.stringify_keys
 					safe_attrs = if respond_to? :sanitize_for_mass_assignment


### PR DESCRIPTION
c.f. https://github.com/rails/rails/blob/v3.1.0.rc4/activerecord/lib/active_record/base.rb#L1524
