### PR TITLE
default value via association fix

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -79,27 +79,26 @@ module DefaultValueFor
 	end
 
 	module InstanceMethods
-		def initialize_with_defaults(attrs = nil, *args)
-			initialize_without_defaults(attrs, *args) do
-				if attrs
-					stringified_attrs = attrs.stringify_keys
-					safe_attrs = if respond_to? :sanitize_for_mass_assignment
-						sanitize_for_mass_assignment(stringified_attrs)
-					else
-						remove_attributes_protected_from_mass_assignment(stringified_attrs)
-					end
-					safe_attribute_names = safe_attrs.keys.map do |x|
-						x.to_s
-					end
+		def initialize_with_defaults(attrs = nil, *args, &block)
+			initialize_without_defaults(attrs, *args, &block)
+			if attrs
+				stringified_attrs = attrs.stringify_keys
+				safe_attrs = if respond_to? :sanitize_for_mass_assignment
+					sanitize_for_mass_assignment(stringified_attrs)
+				else
+					remove_attributes_protected_from_mass_assignment(stringified_attrs)
 				end
-				self.class._default_attribute_values.each do |attribute, container|
-					if safe_attribute_names.nil? || !safe_attribute_names.any? { |attr_name| attr_name =~ /^#{attribute}($|\()/ }
-						__send__("#{attribute}=", container.evaluate(self))
-						changed_attributes.delete(attribute)
-					end
+				safe_attribute_names = safe_attrs.keys.map do |x|
+					x.to_s
 				end
-				yield(self) if block_given?
 			end
+			self.class._default_attribute_values.each do |attribute, container|
+				if safe_attribute_names.nil? || !safe_attribute_names.any? { |attr_name| attr_name =~ /^#{attribute}($|\()/ }
+					__send__("#{attribute}=", container.evaluate(self))
+					changed_attributes.delete(attribute)
+				end
+			end
+			yield(self) if block_given?
 		end
 	end
 end

--- a/test.rb
+++ b/test.rb
@@ -220,19 +220,18 @@ class DefaultValuePluginTest < Test::Unit::TestCase
 		assert_same object, $instance
 	end
 
-	# This is no longer supported starting from Rails 3.1 thanks to ActiveRecord changes.
-	# def test_can_specify_default_value_via_association
-	# 	user = User.create(:username => 'Kanako', :default_number => 123)
-	# 	define_model_class do
-	# 		belongs_to :user
-	# 
-	# 		default_value_for :number do |n|
-	# 			n.user.default_number
-	# 		end
-	# 	end
-	# 	object = user.numbers.create
-	# 	assert_equal 123, object.number
-	# end
+	def test_can_specify_default_value_via_association
+		user = User.create(:username => 'Kanako', :default_number => 123)
+		define_model_class do
+			belongs_to :user
+
+			default_value_for :number do |n|
+				n.user.default_number
+			end
+		end
+		object = user.numbers.create
+		assert_equal 123, object.number
+	end
 
 	def test_default_values
 		define_model_class do


### PR DESCRIPTION
reimplemented default value via association test case commented out here: SHA: 953a2782c6bd

pass given block to #initialize (aka initialize_without_defaults) and then post process.
basically pulled the block from #initialize_without_defaults into a post-process script. from the diff it looks like I changed a lot but i only passed the incoming &block along and left-shifted (<--) your block

all tests passing (ruby 1.9.2 P290)
