### PR TITLE
Respect ActiveRecord::Base#new without_protection option

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -94,7 +94,9 @@ module DefaultValueFor
 			initialize_without_defaults(attrs, options, &block)
 			if attrs
 				stringified_attrs = attrs.stringify_keys
-				safe_attrs = if respond_to? :sanitize_for_mass_assignment
+				safe_attrs = if options[:without_protection]
+					stringified_attrs
+				elsif respond_to? :sanitize_for_mass_assignment
 					sanitize_for_mass_assignment(stringified_attrs)
 				else
 					remove_attributes_protected_from_mass_assignment(stringified_attrs)

--- a/test.rb
+++ b/test.rb
@@ -258,7 +258,7 @@ class DefaultValuePluginTest < Test::Unit::TestCase
 
 	def test_doesnt_conflict_with_overrided_initialize_method_in_model_class
 		define_model_class do
-			def initialize(attrs = {})
+			def initialize(attrs = {}, opts = {})
 				@initialized = true
 				super(:count => 5678)
 			end
@@ -366,5 +366,19 @@ class DefaultValuePluginTest < Test::Unit::TestCase
 		options_dup = options.dup
 		object = TestClass.new(options)
 		assert_equal(options_dup, options)
+	end
+
+	def test_initialization_without_protection
+		define_model_class do
+		  attr_accessor :protected
+		  attr_protected :protected
+		  default_value_for :protected, 5
+		end
+
+		object = TestClass.new(:protected => 10)
+		assert_equal(object.protected, 5)
+
+		object = TestClass.new({ :protected => 10 }, :without_protection => true)
+		assert_equal(object.protected, 10)
 	end
 end


### PR DESCRIPTION
ActiveRecord::AttributeAssignment#assign_attributes – and thus by extension ActiveRecord::Base#initialize – support passing of a second hash alongside the attributes. If that hash contains :without_protection => true, the attributes are not sanitized.

IMO, default_value_for should also respect that option and the attached changes add that support.
