### PR TITLE
Do not see false as blank at boolean columns

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -146,8 +146,15 @@ module DefaultValueFor
         next unless self.new_record? || self.class._all_default_attribute_values_not_allowing_nil.include?(attribute)
         
         connection_default_value_defined = new_record? && respond_to?("#{attribute}_changed?") && !__send__("#{attribute}_changed?")
+        column = self.class.columns.select{|c| c.name == attribute}.first
         
-        next unless connection_default_value_defined || self.attributes[attribute].blank?
+        attribute_blank = if column && column.type == :boolean
+          self.attributes[attribute] == nil ? true : false
+        else 
+          self.attributes[attribute].blank? ? true : false
+        end
+        
+        next unless connection_default_value_defined || attribute_blank
         
         # allow explicitly setting nil through allow nil option
         next if @initialization_attributes.is_a?(Hash) && @initialization_attributes.has_key?(attribute) && !self.class._all_default_attribute_values_not_allowing_nil.include?(attribute)

--- a/test.rb
+++ b/test.rb
@@ -55,6 +55,7 @@ end
 ActiveRecord::Base.connection.create_table(:numbers, :force => true) do |t|
   t.string :type
   t.integer :number
+  t.boolean :flag
   t.integer :count, :null => false, :default => 1
   t.integer :user_id
   t.timestamp :timestamp
@@ -138,7 +139,19 @@ class DefaultValuePluginTest < Test::Unit::TestCase
     assert_equal 1234, TestClass.find(object.id).number
   end
 
-   def test_overwrites_db_default
+  def test_does_not_see_false_as_blank_at_boolean_columns_for_existing_records
+    define_model_class do
+      default_value_for(:flag, :allows_nil => false) { true }
+    end
+    
+    object = TestClass.create
+    
+    # allows nil for existing records
+    object.update_attribute(:flag, false)
+    assert_equal false, TestClass.find(object.id).flag
+  end
+
+  def test_overwrites_db_default
     define_model_class do
       default_value_for :count, 1234
     end


### PR DESCRIPTION
Given a record with a boolean attribute "flag" set to true (default value is true).

When I try to change the column of the existing record to false through update_attribute(:flag, false)

Then attributes[attribute] == false
And attributes[attribute].blank? == true
And default_value_for sets the attribute to its defult value "true".

But the attribute should be set to false.

That's why I changed default_value_for to look for attributes[attribute] == nil instead of attributes[attribute].blank? before setting the default value if it's a boolean column.
