### PR TITLE
Use feature detection rather than version

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -136,7 +136,7 @@ module DefaultValueFor
         end
       end
 
-      if ActiveRecord::VERSION::MAJOR < 4
+      if self.class.respond_to? :protected_attributes
         super(attributes, options)
       else
         super(attributes)


### PR DESCRIPTION
This allows rails 4 users to use the protected_attributes gem along with
default_value_for.
