### PR TITLE
Adding default value in subclass causes default values from superclass to not be saved

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -201,6 +201,18 @@ class DefaultValuePluginTest < TestCaseClass
     assert_equal 1234, object.number
   end
 
+  def test_default_values_in_superclass_are_saved_in_subclass
+    define_model_class("TestSuperClass") do
+      default_value_for :number, 1234
+    end
+    define_model_class("TestClass", "TestSuperClass") do
+      default_value_for :flag, true
+    end
+    object = TestClass.new
+    object.save!
+    assert_equal object, TestClass.find_by_number(1234)
+  end
+
   def test_default_values_in_subclass
     define_model_class("TestSuperClass") do
     end


### PR DESCRIPTION
This started happening in Rails 4 with default_value_for 3.0.0.
I don't have a fix for this yet, but I wanted to get up the failing test case for this issue while I investigate a proper fix.
