### PR TITLE
Fix saving default value from superclass in Rails 4

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -144,7 +144,7 @@ module DefaultValueFor
     end
 
     def attributes_for_create(attribute_names)
-      attribute_names += _default_attribute_values.keys.map(&:to_s)
+      attribute_names += self.class._all_default_attribute_values.keys.map(&:to_s)
       super
     end
 

--- a/test.rb
+++ b/test.rb
@@ -201,6 +201,18 @@ class DefaultValuePluginTest < TestCaseClass
     assert_equal 1234, object.number
   end
 
+  def test_default_values_in_superclass_are_saved_in_subclass
+    define_model_class("TestSuperClass") do
+      default_value_for :number, 1234
+    end
+    define_model_class("TestClass", "TestSuperClass") do
+      default_value_for :flag, true
+    end
+    object = TestClass.create!
+    assert_equal object.id, TestClass.find_by_number(1234).id
+    assert_equal object.id, TestClass.find_by_flag(true).id
+  end
+
   def test_default_values_in_subclass
     define_model_class("TestSuperClass") do
     end


### PR DESCRIPTION
- Adding default value(s) in a subclass was causing default values from the superclass to not be saved.
