### PR TITLE
[Fix] Added compatibility with new Rails 4.2 APIs

### DIFF
--- a/Gemfile.rails.4.2.rb
+++ b/Gemfile.rails.4.2.rb
@@ -1,0 +1,4 @@
+instance_eval File.read(File.expand_path('../Gemfile', __FILE__))
+gem 'activesupport', '~> 4.2.0.beta.4'
+gem 'activerecord', '~> 4.2.0.beta.4'
+gem 'railties', '~> 4.2.0.beta.4'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ u.last_seen  # => Mon Sep 22 17:28:38 +0200 2008
 
 ## Installation
 
-### Rails 3.2 - 4.1 / Ruby 1.9.3 and higher
+### Rails 3.2 - 4.2 / Ruby 1.9.3 and higher
 
 The current version of default_value_for (3.0.x) is compatible with Rails 3.2 or higher, and Ruby 1.9.3 and higher.
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ task :test do
   ruby "test.rb"
 end
 
-['3.2', '4.0', '4.1'].each do |version|
+['3.2', '4.0', '4.1', '4.2'].each do |version|
   dotless = version.delete('.')
 
   namespace :bundle do

--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -166,7 +166,11 @@ module DefaultValueFor
         next if @initialization_attributes.is_a?(Hash) && @initialization_attributes.has_key?(attribute) && !self.class._all_default_attribute_values_not_allowing_nil.include?(attribute)
 
         __send__("#{attribute}=", container.evaluate(self))
-        changed_attributes.delete(attribute)
+        if self.class.private_instance_methods.include? :clear_attribute_changes
+          clear_attribute_changes attribute
+        else
+          changed_attributes.delete(attribute)
+        end
       end
     end
   end


### PR DESCRIPTION
Using the publicly-available private method `ActiveRecord::Dirty#clear_attribute_changes` (see https://github.com/rails/rails/pull/17545) will solve the compatibility issues with Rails 4.2. 

This will fix issue #38 too.
