### PR TITLE
Fix order dependent tests

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -75,10 +75,6 @@ class Number < ActiveRecord::Base
 end
 
 class DefaultValuePluginTest < TestCaseClass
-
-  # SCREAMING RED HOT TODO: Fix this
-  i_suck_and_my_tests_are_order_dependent!
-
   def setup
     Number.create(:number => 9876)
   end


### PR DESCRIPTION
Caution:  I'm not totally certain why the ancestry issue with TestClass and TestSuperClass is causing test contamination from the "test_default_values_in_superclass_are_saved_in_subclass" test but not the others.  Thoughts?  This should fix #47 if the solution used here or discovered here helps fix it for real.

Work in progress resolution of a test order dependence fix
By adding minitest_bisect to the Gemfile and bundling, we can determine the test causing contamination.

In this case, test_default_values_in_superclass_are_saved_in_subclass|test_can_specify_default_value_via_association.

Fix test_default_values_in_superclass_are_saved_in_subclass, by changing the subclass from TestClass to TestClass2 to avoid polluting TestClass with an ancestor TestSuperclass which has a default_value for number.

See more below:

```
~/Code/github/default_value_for (fix_order_dependent_tests) (2.0.0-p594) + bundle exec ruby test.rb

Testing with Active Record version 4.1.8

Run options: --seed 9895

# Running:

.........................F...

Finished in 0.200866s, 144.3749 runs/s, 224.0300 assertions/s.

  1) Failure:
DefaultValuePluginTest#test_can_specify_default_value_via_association [test.rb:360]:
Expected: 123
  Actual: 1234

29 runs, 45 assertions, 1 failures, 0 errors, 0 skips
10:10:27 ~/Code/github/default_value_for (fix_order_dependent_tests) (2.0.0-p594) - be minitest_bisect --seed 9895 test.rb
/Users/joerafaniello/.gem/ruby/2.0.0/gems/minitest-bisect-1.2.0/lib/minitest/bisect.rb:34: warning: literal in condition
reproducing...
reproduced
# of culprit methods: 16
# of culprit methods: 8
# of culprit methods: 4
# of culprit methods: 4
# of culprit methods: 2
# of culprit methods: 2
# of culprit methods: 1
# of culprit methods: 1

Minimal methods found in 8 steps:

ruby  -e 'require "./test.rb"' -- --seed 9895 --server 34855 -n "/^(?:DefaultValuePluginTest#(?:test_default_values_in_superclass_are_saved_in_subclass|test_can_specify_default_value_via_association))$/"

Final reproduction:


Testing with Active Record version 4.1.8

Run options: --seed 9895 -n "/^(?:DefaultValuePluginTest#(?:test_default_values_in_superclass_are_saved_in_subclass|test_can_specify_default_value_via_association))$/"

# Running:

.F

Finished in 0.040055s, 49.9313 runs/s, 74.8970 assertions/s.

  1) Failure:
DefaultValuePluginTest#test_can_specify_default_value_via_association [/Users/joerafaniello/Code/github/default_value_for/test.rb:360]:
Expected: 123
  Actual: 1234

2 runs, 3 assertions, 1 failures, 0 errors, 0 skips
```
