### PR TITLE
remove non-column attributes on create

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -144,7 +144,9 @@ module DefaultValueFor
     end
 
     def attributes_for_create(attribute_names)
-      attribute_names += self.class._all_default_attribute_values.keys.map(&:to_s)
+      attribute_names += self.class._all_default_attribute_values.keys.map(&:to_s).find_all { |name|
+        self.class.columns_hash.key?(name)
+      }
       super
     end
 

--- a/test.rb
+++ b/test.rb
@@ -59,6 +59,7 @@ ActiveRecord::Base.connection.create_table(:numbers, :force => true) do |t|
   t.integer :count, :null => false, :default => 1
   t.integer :user_id
   t.timestamp :timestamp
+  t.text :stuff
   t.boolean :flag
 end
 
@@ -99,6 +100,20 @@ class DefaultValuePluginTest < TestCaseClass
       end
     end
     klass.class_eval(&block) if block_given?
+  end
+
+  def test_default_value_on_attribute_methods
+    define_model_class do
+      serialize :stuff
+      default_value_for :color, :green
+      def color; (self.stuff || {})[:color]; end
+      def color=(val)
+        self.stuff ||= {}
+        self.stuff[:color] = val
+      end
+    end
+    object = TestClass.create
+    assert_equal :green, object.color
   end
 
   def test_default_value_can_be_passed_as_argument


### PR DESCRIPTION
rails/rails@fb2a1c4b removed a check for "real" columns from the `attributes_for_update` method.
In Rails 4.2, default values for attributes that are not actual columns
would be sent to the database.  Rails < 4.2 would remove these columns.

This patch removes non-columns from the default values list befor
sending it to Rails.
