### PR TITLE
Add a note to the README about default_value_for-matchers gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ instead. This is in part the inspiration for the +default_values+ syntax.
 
 ### RSpec
 
-[default_value_for-matchers](https://github.com/kami30k/default_value_for) provides RSpec matchers for testing `default_value_for` method.
+[default_value_for-matchers](https://github.com/kami30k/default_value_for-matchers) provides RSpec matchers for testing `default_value_for` method.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ default_value_for(:uuid) { UuidGenerator.new.generate_uuid }
 
 instead. This is in part the inspiration for the +default_values+ syntax.
 
+## Testing
+
+### RSpec
+
+[default_value_for-matchers](https://github.com/kami30k/default_value_for) provides RSpec matchers for testing `default_value_for` method.
+
+For example:
+
+```ruby
+it { is_expected.to have_default_value_for(:name).with_value('(no name)').and_disallow_nil }
+```
+
 ## Rules
 
 ### Instantiation of new record


### PR DESCRIPTION
I've needed a RSpec matcher for `default_value_for` gem, so I was looking for a solution of it.
I found #42, and I totally agree with @norman 's comment:

> Once a pull request is merged into a project, the project maintainers then become responsible for mantaining that code as long as it's there - in this case that means keeping up with possible changes in RSpec, handling bug reports from people about the matchers, etc.

So I've implemented the matchers and published as gem:
https://github.com/kami30k/default_value_for-matchers

Please merge this PR if you think this gem is useful.
Thanks!