### PR TITLE
Fix for concurrency

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -116,7 +116,7 @@ module DefaultValueFor
 
     def _all_default_attribute_values_not_allowing_nil
       return _default_attribute_values_not_allowing_nil unless superclass.respond_to?(:_default_attribute_values_not_allowing_nil)
-      result = superclass._all_default_attribute_values_not_allowing_nil.concat(_default_attribute_values_not_allowing_nil)
+      result = superclass._all_default_attribute_values_not_allowing_nil + _default_attribute_values_not_allowing_nil
       result.uniq!
       result
     end


### PR DESCRIPTION
When running concurrently in JRuby, in STI models with defaults at multiple levels, the concat method may trigger the following error:

```
ConcurrencyError: Detected invalid array contents due to unsynchronized modifications with concurrent users
org/jruby/RubyArray.java:1422:in `concat'
/home/agios/dotfiles/tag-dev/rbenv/versions/jruby-9.0.1.0/lib/ruby/gems/shared/gems/default_value_for-3.0.1/lib/default_value_for.rb:119:in `_all_default_attribute_values_not_allowing_nil'
```