### PR TITLE
Add Rails 5.0 support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -11,7 +11,11 @@ appraise 'rails-41' do
 end
 
 appraise 'rails-42' do
-  gem 'activesupport', '~> 4.2.0.rc.3'
-  gem 'activerecord', '~> 4.2.0.rc.3'
-  gem 'railties', '~> 4.2.0.rc.3'
+  gem 'activerecord', '~> 4.2.0'
+end
+
+appraise 'rails-50' do
+  gem 'activesupport', '~> 5.0.0.beta1'
+  gem 'activerecord', '~> 5.0.0.beta1'
+  gem 'railties', '~> 5.0.0.beta1'
 end

--- a/default_value_for.gemspec
+++ b/default_value_for.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
     'lib/default_value_for.rb',
     'lib/default_value_for/railtie.rb'
   ]
-  s.add_dependency 'activerecord', '>= 3.2.0', '< 5.0'
-  s.add_development_dependency 'railties', '>= 3.2.0', '< 5.0'
+  s.add_dependency 'activerecord', '>= 3.2.0', '< 5.1'
+  s.add_development_dependency 'railties', '>= 3.2.0', '< 5.1'
   s.add_development_dependency 'minitest', '>= 4.2'
   s.add_development_dependency 'minitest-around'
   s.add_development_dependency 'appraisal'

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -2,7 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 4.2.0"
+gem "activesupport", "~> 5.0.0.beta1"
+gem "activerecord", "~> 5.0.0.beta1"
+gem "railties", "~> 5.0.0.beta1"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"

--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -177,7 +177,7 @@ module DefaultValueFor
 
         __send__("#{attribute}=", container.evaluate(self))
         if respond_to?(:clear_attribute_changes, true)
-          clear_attribute_changes attribute
+          clear_attribute_changes [attribute] if has_attribute?(attribute)
         else
           changed_attributes.delete(attribute)
         end

--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -176,7 +176,7 @@ module DefaultValueFor
                 !self.class._all_default_attribute_values_not_allowing_nil.include?(attribute)
 
         __send__("#{attribute}=", container.evaluate(self))
-        if self.class.private_instance_methods.include? :clear_attribute_changes
+        if respond_to?(:clear_attribute_changes, true)
           clear_attribute_changes attribute
         else
           changed_attributes.delete(attribute)


### PR DESCRIPTION
The changes are all in `clear_attribute_changes`:

* it's now public on ActiveRecord (though not ActiveModel) -- this might be accidental (@sgrif?), but checking `respond_to?` is more correct anyway
* it requires its argument to be an array
* it raises `ActiveModel::MissingAttributeError` if called with a non-attribute