### PR TITLE
New API makes #clear_attribute_changes public

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -178,6 +178,8 @@ module DefaultValueFor
         __send__("#{attribute}=", container.evaluate(self))
         if self.class.private_instance_methods.include? :clear_attribute_changes
           clear_attribute_changes attribute
+        elsif self.class.instance_methods.include? :clear_attribute_changes
+          clear_attribute_changes [attribute]
         else
           changed_attributes.delete(attribute)
         end


### PR DESCRIPTION
Hi,
I apologize that I don't know the Rails API well enough to eliminate one of the options in the `if` statement here.  

But I was getting an error about trying to modify HashWithIndifferentAccess and found that this location was previously modified for the same reason.  What I seem to see is that in version 5.0.0beta2, `clear_attribute_changes` is no longer a private instance method so the first test was failing.

When I try to call `clear_attribute_changes` with _attribute_, I get an error that's expecting to be able to call `#each` on the object.  Hence a third possibility, which will pass an array of values to the method in order to correctly clear the error.

Thanks!
Tyler
