### PR TITLE
Add Rails 5.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.lock
 *.gem
+gemfiles/.bundle

--- a/Appraisals
+++ b/Appraisals
@@ -15,7 +15,9 @@ appraise 'rails-42' do
 end
 
 appraise 'rails-50' do
-  gem 'activesupport', '~> 5.0.0'
   gem 'activerecord', '~> 5.0.0'
-  gem 'railties', '~> 5.0.0'
+end
+
+appraise 'rails-51' do
+  gem 'activerecord', '~> 5.1.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -5,13 +5,13 @@ task :test do
   ruby "test.rb"
 end
 
-['3.2', '4.0', '4.1', '4.2'].each do |version|
+['3.2', '4.0', '4.1', '4.2', '5.0'].each do |version|
   dotless = version.delete('.')
 
   namespace :bundle do
     desc "Bundle with Rails #{version}.x"
     task :"rails#{dotless}" do
-      ENV['BUNDLE_GEMFILE'] = "Gemfile.rails.#{version}.rb"
+      ENV['BUNDLE_GEMFILE'] = "gemfiles/rails_#{dotless}.gemfile"
       sh "bundle"
     end
   end
@@ -19,7 +19,7 @@ end
   namespace :test do
     desc "Test with Rails #{version}.x"
     task :"rails#{dotless}" do
-      ENV['BUNDLE_GEMFILE'] = "Gemfile.rails.#{version}.rb"
+      ENV['BUNDLE_GEMFILE'] = "gemfiles/rails_#{dotless}.gemfile"
       ruby "test.rb"
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ task :test do
   ruby "test.rb"
 end
 
-['3.2', '4.0', '4.1', '4.2', '5.0'].each do |version|
+['3.2', '4.0', '4.1', '4.2', '5.0', '5.1'].each do |version|
   dotless = version.delete('.')
 
   namespace :bundle do

--- a/default_value_for.gemspec
+++ b/default_value_for.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
     'lib/default_value_for.rb',
     'lib/default_value_for/railtie.rb'
   ]
-  s.add_dependency 'activerecord', '>= 3.2.0', '< 5.1'
-  s.add_development_dependency 'railties', '>= 3.2.0', '< 5.1'
+  s.add_dependency 'activerecord', '>= 3.2.0', '< 5.2'
+  s.add_development_dependency 'railties', '>= 3.2.0', '< 5.2'
   s.add_development_dependency 'minitest', '>= 4.2'
   s.add_development_dependency 'minitest-around'
   s.add_development_dependency 'appraisal'

--- a/gemfiles/rails_32.gemfile
+++ b/gemfiles/rails_32.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3", "~> 1.3.8"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3", "~> 1.3.8"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3", "~> 1.3.8"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -13,4 +13,4 @@ platforms :ruby do
   gem "sqlite3", "~> 1.3.8"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -15,4 +15,4 @@ platforms :ruby do
   gem "sqlite3", "~> 1.3.8"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0.0"
+gem "activerecord", "~> 5.1.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"

--- a/test.rb
+++ b/test.rb
@@ -156,7 +156,7 @@ class DefaultValuePluginTest < TestCaseClass
 
   def test_doesnt_overwrite_explicitly_provided_nil_values_in_mass_assignment
     Book.default_value_for :number, 1234
-    assert_equal nil, Book.new(:number => nil).number
+    assert_nil Book.new(:number => nil).number
   end
 
   def test_overwrites_explicitly_provided_nil_values_in_mass_assignment


### PR DESCRIPTION
Adds support for Rails 5.1, unlocking the gemspec for the new release. No incompatibilities. Also cleans up Rakefile tasks (they were broken) and removes deprecation warning in tests.

Closes #65 