### PR TITLE
Allow any version less than rails 6

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -19,3 +19,9 @@ appraise 'rails-50' do
   gem 'activerecord', '~> 5.0.0'
   gem 'railties', '~> 5.0.0'
 end
+
+appraise 'rails-51' do
+  gem 'activesupport', '~> 5.1.0'
+  gem 'activerecord', '~> 5.1.0'
+  gem 'railties', '~> 5.1.0'
+end

--- a/default_value_for.gemspec
+++ b/default_value_for.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
     'lib/default_value_for.rb',
     'lib/default_value_for/railtie.rb'
   ]
-  s.add_dependency 'activerecord', '>= 3.2.0', '< 5.1'
-  s.add_development_dependency 'railties', '>= 3.2.0', '< 5.1'
+  s.add_dependency 'activerecord', '>= 3.2.0', '< 6'
+  s.add_development_dependency 'railties', '>= 3.2.0', '< 6'
   s.add_development_dependency 'minitest', '>= 4.2'
   s.add_development_dependency 'minitest-around'
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
Not sure if you want to be as open as < 6 but it seems like a pain to lock it down to just 5.0 when it works perfectly with 5.1  and chances are high it will work with 5.2

Similar to #65 