### PR TITLE
Convert instances of ActionController::Parameters to Hashes before as…

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -124,6 +124,7 @@ module DefaultValueFor
 
   module InstanceMethods
     def initialize(attributes = nil, options = {})
+      attributes = attributes.to_h if attributes.is_a?(ActionController::Parameters)
       @initialization_attributes = attributes.is_a?(Hash) ? attributes.stringify_keys : {}
 
       unless options[:without_protection]


### PR DESCRIPTION
…signing default attributes

This addresses issue #69 

Convert initialization attributes to a hash if they're an instance of `ActionController::Parameters`
This way, `default_value_for` does not override nested attributes on initialization