### PR TITLE
Fix regression w/ writer and no reader

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -156,12 +156,18 @@ module DefaultValueFor
 
         connection_default_value_defined = new_record? && respond_to?("#{attribute}_changed?") && !__send__("#{attribute}_changed?")
 
-        column = self.class.columns.detect {|c| c.name == attribute}
-        attribute_blank = if column && column.type == :boolean
-          send(attribute).nil?
-        else
-          send(attribute).blank?
-        end
+        attribute_blank = if attributes.has_key?(attribute)
+                            column = self.class.columns.detect { |c| c.name == attribute }
+                            if column && column.type == :boolean
+                              attributes[attribute].nil?
+                            else
+                              attributes[attribute].blank?
+                            end
+                          elsif respond_to?(attribute)
+                            send(attribute).nil?
+                          else
+                            instance_variable_get("@#{attribute}").nil?
+                          end
         next unless connection_default_value_defined || attribute_blank
 
         # allow explicitly setting nil through allow nil option

--- a/test.rb
+++ b/test.rb
@@ -234,6 +234,14 @@ class DefaultValuePluginTest < TestCaseClass
     assert_equal 'hi', Book.new.hello
   end
 
+  def test_works_on_attributes_that_only_have_writers
+    Book.class_eval do
+      default_value_for :hello, "hi"
+      attr_writer :hello
+    end
+    assert_equal 'hi', Book.new.instance_variable_get('@hello')
+  end
+
   def test_doesnt_conflict_with_overrided_initialize_method_in_model_class
     Book.class_eval do
       def initialize(attrs = {})


### PR DESCRIPTION
According to the README, this behavior is expected:
https://github.com/FooBarWidget/default_value_for/tree/1d1b2592eb00741a290d8406353846ddd8aae335#attributes-that-arent-database-columns

However, it fails after 6f83fd6fe1d4a3b175c4529391ef3f8879bbb4eb

This change allows all three types of scenarios that are expected:

* Normal attributes (usually backed by columns)
* Attributes not found within the attributes hash (ex: ActiveRecord::Store) but are accessed via a reader
* Attributes with *only* a writer and no reader (as in the README link above)

Fixes #72