### PR TITLE
Prefer a more performant column lookup

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -157,7 +157,7 @@ module DefaultValueFor
         connection_default_value_defined = new_record? && respond_to?("#{attribute}_changed?") && !__send__("#{attribute}_changed?")
 
         attribute_blank = if attributes.has_key?(attribute)
-                            column = self.class.columns.detect { |c| c.name == attribute }
+                            column = self.class.columns_hash[attribute]
                             if column && column.type == :boolean
                               attributes[attribute].nil?
                             else


### PR DESCRIPTION
I ran the tests with `appraisal bundle exec rake test` and everything is green, but when I run the tests with Ruby 2.4.2 I am getting seemingly unrelated errors, which I think come from mixing Ruby 2.4.2 with old versions of Rails (like 3.2).  Not sure what is the "right" way to run the tests locally, otherwise.