### PR TITLE
Convert instances of ActionController::Parameters to Hashes before assigning default attributes

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,27 +1,34 @@
 appraise 'rails-32' do
   gem 'activerecord', '~> 3.2.21'
+  gem 'actionpack', '~> 3.2.21'
 end
 
 appraise 'rails-40' do
   gem 'activerecord', '~> 4.0.12'
+  gem 'actionpack', '~> 4.0.12'
 end
 
 appraise 'rails-41' do
   gem 'activerecord', '~> 4.1.8'
+  gem 'actionpack', '~> 4.1.8'
 end
 
 appraise 'rails-42' do
   gem 'activerecord', '~> 4.2.0'
+  gem 'actionpack', '~> 4.2.0'
 end
 
 appraise 'rails-50' do
   gem 'activerecord', '~> 5.0.0'
+  gem 'actionpack', '~> 5.0.0'
 end
 
 appraise 'rails-51' do
   gem 'activerecord', '~> 5.1.0'
+  gem 'actionpack', '~> 5.1.0'
 end
 
 appraise 'rails-52' do
   gem 'activerecord', '~> 5.2.0'
+  gem 'actionpack', '~> 5.2.0'
 end

--- a/default_value_for.gemspec
+++ b/default_value_for.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '>= 4.2'
   s.add_development_dependency 'minitest-around'
   s.add_development_dependency 'appraisal'
+  s.add_development_dependency 'actionpack', '>= 3.2.0', '< 6.0'
 end

--- a/gemfiles/rails_32.gemfile
+++ b/gemfiles/rails_32.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 3.2.21"
+gem "actionpack", "~> 3.2.21"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.0.12"
+gem "actionpack", "~> 4.0.12"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.1.8"
+gem "actionpack", "~> 4.1.8"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.0"
+gem "actionpack", "~> 4.2.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.0"
+gem "actionpack", "~> 5.0.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.0"
+gem "actionpack", "~> 5.1.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.2.0"
+gem "actionpack", "~> 5.2.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"

--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -124,6 +124,7 @@ module DefaultValueFor
 
   module InstanceMethods
     def initialize(attributes = nil, options = {})
+      attributes = attributes.to_h if attributes.is_a?(ActionController::Parameters)
       @initialization_attributes = attributes.is_a?(Hash) ? attributes.stringify_keys : {}
 
       unless options[:without_protection]

--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -124,7 +124,7 @@ module DefaultValueFor
 
   module InstanceMethods
     def initialize(attributes = nil, options = {})
-      attributes = attributes.to_h if attributes.is_a?(ActionController::Parameters)
+      attributes = attributes.to_h if attributes.respond_to?(:to_h)
       @initialization_attributes = attributes.is_a?(Hash) ? attributes.stringify_keys : {}
 
       unless options[:without_protection]

--- a/test.rb
+++ b/test.rb
@@ -22,9 +22,42 @@ require 'bundler/setup'
 require 'minitest/autorun'
 require 'minitest/around/unit'
 require 'active_record'
+require 'action_pack'
 
 if ActiveSupport::VERSION::MAJOR == 3
   require 'active_support/core_ext/logger'
+end
+
+if ActionPack::VERSION::MAJOR > 3
+  require 'action_controller'
+end
+
+# Handle an edge-case when using Arel 5 (i.e. Rails <= 4.1) with Ruby >= 2.4:
+# See: https://github.com/rails/arel/commit/dc85a6e9c74942945ad696f5da4d82490a85b865
+# See: https://stackoverflow.com/a/51481088
+rails_match_data = RUBY_VERSION.match(/\A(?<major>\d+).(?<minor>\d+)/)
+rails_2_4_or_newer = rails_match_data[:major].to_i > 2 || (rails_match_data[:major].to_i == 2 && rails_match_data[:minor].to_i >= 4)
+arel_match_data = Arel::VERSION.match(/\A(?<major>\d+).(?<minor>\d+)/)
+arel_older_than_7_1 = arel_match_data[:major].to_i < 7 || (arel_match_data[:major].to_i == 7 && arel_match_data[:minor].to_i < 1)
+
+if rails_2_4_or_newer && arel_older_than_7_1
+  module Arel
+    module Visitors
+      class DepthFirst < Arel::Visitors::Visitor
+        alias :visit_Integer :terminal
+      end
+
+      class Dot < Arel::Visitors::Visitor
+        alias :visit_Integer :visit_String
+      end
+
+      # The super class for ToSql changed with Arel 6
+      # See: https://github.com/rails/arel/commit/a6a7c75ff486657909e20e2f48764136caa5e87e#diff-3538aead5b80677372eea0e903ff728eR7
+      class ToSql < (Arel::VERSION[/\A\d+/].to_i >= 6 ? Arel::Visitors::Reduce : Arel::Visitors::Visitor)
+        alias :visit_Integer :literal
+      end
+    end
+  end
 end
 
 begin
@@ -35,7 +68,8 @@ end
 
 require 'default_value_for'
 
-puts "\nTesting with Active Record version #{ActiveRecord::VERSION::STRING}\n\n"
+puts "\nTesting with Active Record version #{ActiveRecord::VERSION::STRING}"
+puts "\nTesting with Action Pack version #{ActionPack::VERSION::STRING}\n\n"
 
 ActiveRecord::Base.default_timezone = :local
 ActiveRecord::Base.logger           = Logger.new(STDERR)
@@ -368,6 +402,38 @@ class DefaultValuePluginTest < TestCaseClass
 
     user = User.create!(:bio => 'This is a bio')
     assert_equal 'This is a bio', user.bio
+  end
+
+  if ActionPack::VERSION::MAJOR > 3
+    def test_doesnt_overwrite_explicitly_provided_nil_values_in_mass_assignment_with_action_controller_parameters
+      Book.default_value_for :number, 1234
+
+      assert_nil Book.new(ActionController::Parameters.new(:number => nil).permit!).number
+    end
+
+    def test_overwrites_explicitly_provided_nil_values_in_mass_assignment_with_action_controller_parameters
+      Book.default_value_for :number, :value => 1234, :allows_nil => false
+
+      assert_equal 1234, Book.new(ActionController::Parameters.new(:number => nil).permit!).number
+    end
+
+    def test_works_with_nested_attributes_with_action_controller_parameters
+      User.accepts_nested_attributes_for :books
+      User.default_value_for :books do
+        [Book.create!(:number => 0)]
+      end
+
+      user = User.create!(ActionController::Parameters.new(:books_attributes => [{:number => 1}]).permit!)
+      assert_equal 1, Book.all.first.number
+    end
+
+    def test_works_with_stored_attribute_accessors_when_initializing_value_that_does_not_allow_nil_with_action_controller_parameters
+      User.store :settings, :accessors => :bio
+      User.default_value_for :bio, :value => 'None given', :allows_nil => false
+
+      user = User.create!(ActionController::Parameters.new(:bio => 'This is a bio').permit!)
+      assert_equal 'This is a bio', user.bio
+    end
   end
 
   if ActiveRecord::VERSION::MAJOR == 3


### PR DESCRIPTION
This builds upon #70.

Convert initialization attributes to a hash if they respond to `to_h`.

1. This will allow to handle instances of `ActionController::Parameters` without making `ActionDispatch` a runtime dependency of this gem, as suggested by https://github.com/FooBarWidget/default_value_for/pull/70#pullrequestreview-180922504.
1. This also adds dedicated tests for the handling of `ActionController::Parameters`.
1. This also fixes an edge-case in tests when using Arel 5 (i.e. Rails <= 4.1) with Ruby >= 2.4.

Closes #69.

### Test results without the fix

```
› bundle exec appraisal rake test
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_32.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 3.2.22.5

Testing with Action Pack version 3.2.22.5

Run options: --seed 56411

# Running:

...................................

Finished in 0.291835s, 119.9308 runs/s, 181.6095 assertions/s.

35 runs, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_40.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 4.0.13

Testing with Action Pack version 4.0.13

Run options: --seed 19827

# Running tests:

.....................................

Finished tests in 0.270046s, 137.0137 tests/s, 196.2629 assertions/s.

37 tests, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_41.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 4.1.16

Testing with Action Pack version 4.1.16

Run options: --seed 24243

# Running:

.....................................

Finished in 0.240286s, 153.9832 runs/s, 220.5705 assertions/s.

37 runs, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_42.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 4.2.10

Testing with Action Pack version 4.2.10

Run options: --seed 59744

# Running:

.....................................

Finished in 0.279463s, 132.3968 runs/s, 189.6494 assertions/s.

37 runs, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_50.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 5.0.7.1

Testing with Action Pack version 5.0.7.1

Run options: --seed 62880

# Running:

..............F

Failure:
DefaultValuePluginTest#test_doesnt_overwrite_explicitly_provided_nil_values_in_mass_assignment_with_action_controller_parameters [test.rb:411]:
Expected 1234 to be nil.


Traceback (most recent call last):
	17: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:63:in `block in autorun'
	16: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:136:in `run'
	15: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:159:in `__run'
	14: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:159:in `map'
	13: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:159:in `block in __run'
	12: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:319:in `run'
	11: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:347:in `with_info_handler'
	10: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:360:in `on_signal'
	 9: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:320:in `block in run'
	 8: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:320:in `each'
	 7: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:321:in `block (2 levels) in run'
	 6: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:334:in `run_one_method'
	 5: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:802:in `record'
	 4: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:802:in `each'
	 3: from /Users/remy/.gem/ruby/2.5.3/gems/minitest-5.11.3/lib/minitest.rb:803:in `block in record'
	 2: from /Users/remy/.gem/ruby/2.5.3/gems/railties-5.0.7.1/lib/rails/test_unit/reporter.rb:23:in `record'
	 1: from /Users/remy/.gem/ruby/2.5.3/gems/railties-5.0.7.1/lib/rails/test_unit/reporter.rb:70:in `format_rerun_snippet'
/Users/remy/.gem/ruby/2.5.3/gems/railties-5.0.7.1/lib/rails/test_unit/reporter.rb:70:in `method': undefined method `test_doesnt_overwrite_explicitly_provided_nil_values_in_mass_assignment_with_action_controller_parameters' for class `Minitest::Result' (NameError)
rake aborted!
Command failed with status (1): [/Users/remy/.rubies/ruby-2.5.3/bin/ruby te...]
/Users/remy/Code/GitLab/default_value_for/Rakefile:5:in `block in <top (required)>'
/Users/remy/.gem/ruby/2.5.3/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/Users/remy/.gem/ruby/2.5.3/bin/bundle:23:in `load'
/Users/remy/.gem/ruby/2.5.3/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

```
› bundle exec appraisal rails-51 rake test
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_51.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 5.1.6.1

Testing with Action Pack version 5.1.6.1

Run options: --seed 57276

# Running:

........F

Failure:
DefaultValuePluginTest#test_doesnt_overwrite_explicitly_provided_nil_values_in_mass_assignment_with_action_controller_parameters [test.rb:411]:
Expected 1234 to be nil.


bin/rails test test.rb:408

............................

Finished in 0.391597s, 94.4849 runs/s, 135.3432 assertions/s.
37 runs, 53 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [/Users/remy/.rubies/ruby-2.5.3/bin/ruby te...]
/Users/remy/Code/GitLab/default_value_for/Rakefile:5:in `block in <top (required)>'
/Users/remy/.gem/ruby/2.5.3/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/Users/remy/.gem/ruby/2.5.3/bin/bundle:23:in `load'
/Users/remy/.gem/ruby/2.5.3/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

```
› bundle exec appraisal rails-52 rake test
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_52.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 5.2.2

Testing with Action Pack version 5.2.2

Run options: --seed 28105

# Running:

...................................F

Failure:
DefaultValuePluginTest#test_doesnt_overwrite_explicitly_provided_nil_values_in_mass_assignment_with_action_controller_parameters [test.rb:411]:
Expected 1234 to be nil.


bin/rails test test.rb:408

.

Finished in 0.374031s, 98.9223 runs/s, 141.6995 assertions/s.
37 runs, 53 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [/Users/remy/.rubies/ruby-2.5.3/bin/ruby te...]
/Users/remy/Code/GitLab/default_value_for/Rakefile:5:in `block in <top (required)>'
/Users/remy/.gem/ruby/2.5.3/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/Users/remy/.gem/ruby/2.5.3/bin/bundle:23:in `load'
/Users/remy/.gem/ruby/2.5.3/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

### Test results with the fix

```
› bundle exec appraisal rake test
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_32.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 3.2.22.5

Testing with Action Pack version 3.2.22.5

Run options: --seed 7448

# Running:

...................................

Finished in 0.278227s, 125.7966 runs/s, 190.4919 assertions/s.

35 runs, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_40.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 4.0.13

Testing with Action Pack version 4.0.13

Run options: --seed 61873

# Running tests:

.....................................

Finished tests in 0.275222s, 134.4369 tests/s, 192.5718 assertions/s.

37 tests, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_41.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 4.1.16

Testing with Action Pack version 4.1.16

Run options: --seed 40983

# Running:

.....................................

Finished in 0.286689s, 129.0597 runs/s, 184.8693 assertions/s.

37 runs, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_42.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 4.2.10

Testing with Action Pack version 4.2.10

Run options: --seed 17124

# Running:

.....................................

Finished in 0.235450s, 157.1459 runs/s, 225.1009 assertions/s.

37 runs, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_50.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 5.0.7.1

Testing with Action Pack version 5.0.7.1

Run options: --seed 37038

# Running:

.....................................

Finished in 0.321052s, 115.2461 runs/s, 165.0823 assertions/s.
37 runs, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_51.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 5.1.6.1

Testing with Action Pack version 5.1.6.1

Run options: --seed 40558

# Running:

.....................................

Finished in 0.408612s, 90.5504 runs/s, 129.7074 assertions/s.
37 runs, 53 assertions, 0 failures, 0 errors, 0 skips
>> BUNDLE_GEMFILE=/Users/remy/Code/GitLab/default_value_for/gemfiles/rails_52.gemfile bundle exec rake test
/Users/remy/.rubies/ruby-2.5.3/bin/ruby test.rb

Testing with Active Record version 5.2.2

Testing with Action Pack version 5.2.2

Run options: --seed 6828

# Running:

.....................................

Finished in 0.391656s, 94.4707 runs/s, 135.3228 assertions/s.
37 runs, 53 assertions, 0 failures, 0 errors, 0 skips
```