### PR TITLE
Support Rails 6; adjust testing deps

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,10 @@
 appraise 'rails-32' do
   gem 'activerecord', '~> 3.2.21'
   gem 'actionpack', '~> 3.2.21'
+
+  platforms :ruby do
+    gem 'sqlite3', '~> 1.3.8'
+  end
 end
 
 appraise 'rails-40' do
@@ -31,4 +35,9 @@ end
 appraise 'rails-52' do
   gem 'activerecord', '~> 5.2.0'
   gem 'actionpack', '~> 5.2.0'
+end
+
+appraise 'rails-60' do
+  gem 'activerecord', '~> 6.0.0'
+  gem 'actionpack', '~> 6.0.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 gemspec
 
 platforms :jruby do
-  gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.3'
+  gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3', '< 61'
   gem 'jruby-openssl', '~> 0.9.4'
 end
 
 platforms :ruby do
-  gem 'sqlite3', '~> 1.3.8'
+  gem 'sqlite3', '~> 1.3'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,18 @@ task :test do
   ruby "test.rb"
 end
 
-['3.2', '4.0', '4.1', '4.2', '5.0', '5.1', '5.2'].each do |version|
+rails_versions = %w(
+  3.2
+  4.0
+  4.1
+  4.2
+  5.0
+  5.1
+  5.2
+  6.0
+)
+
+rails_versions.each do |version|
   dotless = version.delete('.')
 
   namespace :bundle do
@@ -19,6 +30,17 @@ end
   namespace :test do
     desc "Test with Rails #{version}.x"
     task :"rails#{dotless}" do
+      ENV['BUNDLE_GEMFILE'] = "gemfiles/rails_#{dotless}.gemfile"
+      ruby "test.rb"
+    end
+  end
+end
+
+namespace :test do
+  desc "Test with all supported Rails versions"
+  task :railsall do
+    rails_versions.each do |version|
+      dotless = version.delete('.')
       ENV['BUNDLE_GEMFILE'] = "gemfiles/rails_#{dotless}.gemfile"
       ruby "test.rb"
     end

--- a/default_value_for.gemspec
+++ b/default_value_for.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
     'lib/default_value_for.rb',
     'lib/default_value_for/railtie.rb'
   ]
-  s.add_dependency 'activerecord', '>= 3.2.0', '< 6.0'
-  s.add_development_dependency 'railties', '>= 3.2.0', '< 6.0'
+  s.add_dependency 'activerecord', '>= 3.2.0', '< 6.1'
+  s.add_development_dependency 'actionpack', '>= 3.2.0', '< 6.1'
+  s.add_development_dependency 'railties', '>= 3.2.0', '< 6.1'
   s.add_development_dependency 'minitest', '>= 4.2'
   s.add_development_dependency 'minitest-around'
   s.add_development_dependency 'appraisal'
-  s.add_development_dependency 'actionpack', '>= 3.2.0', '< 6.0'
 end

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -6,12 +6,12 @@ gem "activerecord", "~> 4.0.12"
 gem "actionpack", "~> 4.0.12"
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"
+  gem "activerecord-jdbcsqlite3-adapter", ">= 1.3", "< 61"
   gem "jruby-openssl", "~> 0.9.4"
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.3.8"
+  gem "sqlite3", ">= 1.3", "< 2.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -6,12 +6,12 @@ gem "activerecord", "~> 4.1.8"
 gem "actionpack", "~> 4.1.8"
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"
+  gem "activerecord-jdbcsqlite3-adapter", ">= 1.3", "< 61"
   gem "jruby-openssl", "~> 0.9.4"
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.3.8"
+  gem "sqlite3", ">= 1.3", "< 2.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -6,12 +6,12 @@ gem "activerecord", "~> 4.2.0"
 gem "actionpack", "~> 4.2.0"
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"
+  gem "activerecord-jdbcsqlite3-adapter", ">= 1.3", "< 61"
   gem "jruby-openssl", "~> 0.9.4"
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.3.8"
+  gem "sqlite3", ">= 1.3", "< 2.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -6,12 +6,12 @@ gem "activerecord", "~> 5.0.0"
 gem "actionpack", "~> 5.0.0"
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"
+  gem "activerecord-jdbcsqlite3-adapter", ">= 1.3", "< 61"
   gem "jruby-openssl", "~> 0.9.4"
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.3.8"
+  gem "sqlite3", ">= 1.3", "< 2.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -6,12 +6,12 @@ gem "activerecord", "~> 5.1.0"
 gem "actionpack", "~> 5.1.0"
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"
+  gem "activerecord-jdbcsqlite3-adapter", ">= 1.3", "< 61"
   gem "jruby-openssl", "~> 0.9.4"
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.3.8"
+  gem "sqlite3", ">= 1.3", "< 2.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -6,12 +6,12 @@ gem "activerecord", "~> 5.2.0"
 gem "actionpack", "~> 5.2.0"
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.3"
+  gem "activerecord-jdbcsqlite3-adapter", ">= 1.3", "< 61"
   gem "jruby-openssl", "~> 0.9.4"
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.3.8"
+  gem "sqlite3", ">= 1.3", "< 2.0"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_60.gemfile
+++ b/gemfiles/rails_60.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 3.2.21"
-gem "actionpack", "~> 3.2.21"
+gem "activerecord", "~> 6.0.0"
+gem "actionpack", "~> 6.0.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", ">= 1.3", "< 61"
@@ -11,7 +11,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.3.8"
+  gem "sqlite3", ">= 1.3", "< 2.0"
 end
 
 gemspec path: "../"


### PR DESCRIPTION
Adds support for Rails 6 🎉 

Resolves #80, resolves #81, and resolves #82  

sqlite3 needed to be tweaked because the sqlite adapter in Rails 3.2 requires ~>1.3.x but Rails 6 requires >= 1.4. So in general, use >= 1.4 but make an exception for Rails 3.2 testing.

Also tweaked JRuby deps as it looks like they changed versioning schemes.

<img width="404" alt="image" src="https://user-images.githubusercontent.com/2430490/63379462-fc112b00-c359-11e9-9f0f-f1cf0fc74fcb.png">
