### PR TITLE
Fix broken subclass support with Ruby 2.6.

### DIFF
--- a/lib/default_value_for.rb
+++ b/lib/default_value_for.rb
@@ -138,7 +138,7 @@ module DefaultValueFor
       end
 
       if self.class.respond_to? :protected_attributes
-        super(attributes, options)
+        super(attributes.merge(options))
       else
         super(attributes)
       end


### PR DESCRIPTION
This should fix Issue #84 

The object initialize() method can only take a single option, usually a
hash of attribute names/values.  When default_value_for is used in a
subclass all the initial attributes must be merged into a single hash.

I'm not sure the proper way to add test cases for this.