### PR TITLE
remove <= 7.1 rails requirement

### DIFF
--- a/default_value_for.gemspec
+++ b/default_value_for.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
     'lib/default_value_for.rb',
     'lib/default_value_for/railtie.rb'
   ]
-  s.add_dependency 'activerecord', '>= 3.2.0', '< 7.1'
-  s.add_development_dependency 'actionpack', '>= 3.2.0', '< 7.1'
-  s.add_development_dependency 'railties', '>= 3.2.0', '< 7.1'
+  s.add_dependency 'activerecord', '>= 3.2.0'
+  s.add_development_dependency 'actionpack', '>= 3.2.0'
+  s.add_development_dependency 'railties', '>= 3.2.0'
   s.add_development_dependency 'minitest', '>= 4.2'
   s.add_development_dependency 'minitest-around'
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
Unless I am missing something, I didn't see a reason for the < 7.1 version specificity, and it was preventing me from using (my trax_model gem depends on it) in a new rails 7.1.3 project