### PR TITLE
fix CI for Rails 6.1/7.0 + add support for Rails 8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         rails: [61, 70, 71, 72]
 
         # Rails 7.2 requires ruby 3.1 and higher
-        # Rails 8.0 requires ruby 3.2 and higher
+        # Rails 8.0/8.1 requires ruby 3.2 and higher
         include:
           - ruby: "3.0"
             rails: 61
@@ -25,11 +25,19 @@ jobs:
             rails: 80
           - ruby: "3.3"
             rails: 80
+          - ruby: "3.4"
+            rails: 80
+          - ruby: "3.2"
+            rails: 81
+          - ruby: "3.3"
+            rails: 81
+          - ruby: "3.4"
+            rails: 81
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,13 @@
 appraise 'rails-61' do
   gem 'activerecord', '~> 6.1.0'
   gem 'actionpack',   '~> 6.1.0'
+  gem 'concurrent-ruby', '< 1.3.5' # as https://github.com/rails/rails/pull/49372 was never backported
 end
 
 appraise 'rails-70' do
   gem 'activerecord', '~> 7.0.0'
   gem 'actionpack',   '~> 7.0.0'
+  gem 'concurrent-ruby', '< 1.3.5' # as https://github.com/rails/rails/pull/49372 was never backported
 end
 
 appraise 'rails-71' do
@@ -21,6 +23,14 @@ end
 appraise 'rails-80' do
   gem 'activerecord', '~> 8.0.0'
   gem 'actionpack',   '~> 8.0.0'
+  platforms :ruby do
+    gem 'sqlite3', '~> 2.1'
+  end
+end
+
+appraise 'rails-81' do
+  gem 'activerecord', '~> 8.1.0'
+  gem 'actionpack',   '~> 8.1.0'
   platforms :ruby do
     gem 'sqlite3', '~> 2.1'
   end

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ rails_versions = %w(
   7.1
   7.2
   8.0
+  8.1
 )
 
 rails_versions.each do |version|

--- a/default_value_for.gemspec
+++ b/default_value_for.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
     'lib/default_value_for.rb',
     'lib/default_value_for/railtie.rb'
   ]
-  s.add_dependency 'activerecord', '>= 6.1', '< 8.1'
-  s.add_development_dependency 'actionpack', '>= 6.1', '< 8.1'
-  s.add_development_dependency 'railties', '>= 6.1', '< 8.1'
+  s.add_dependency 'activerecord', '>= 6.1', '< 8.2'
+  s.add_development_dependency 'actionpack', '>= 6.1', '< 8.2'
+  s.add_development_dependency 'railties', '>= 6.1', '< 8.2'
   s.add_development_dependency 'minitest', '>= 5.0'
   s.add_development_dependency 'minitest-around'
   s.add_development_dependency 'appraisal'

--- a/gemfiles/rails_61.gemfile
+++ b/gemfiles/rails_61.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 6.1.0"
 gem "actionpack", "~> 6.1.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", ">= 1.3", "< 61"

--- a/gemfiles/rails_81.gemfile
+++ b/gemfiles/rails_81.gemfile
@@ -2,9 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.0.0"
-gem "actionpack", "~> 7.0.0"
-gem "concurrent-ruby", "< 1.3.5"
+gem "activerecord", "~> 8.1.0"
+gem "actionpack", "~> 8.1.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", ">= 1.3", "< 61"
@@ -12,7 +11,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.3"
+  gem "sqlite3", "~> 2.1"
 end
 
 gemspec path: "../"


### PR DESCRIPTION
Rails 8.1 was [released on Oct 22](https://github.com/rails/rails/releases/tag/v8.1.0), and CI is fully [green on my fork](https://github.com/ashkulz/default_value_for/actions/runs/18799815056) with these changes.

Would you be interested in an automated release workflow? I've done that for gems I maintain -- see prontolabs/pronto@c7007deaa060395911ba039604655d6d08fae556 and I've found it helps get over the friction of making a new release :slightly_smiling_face: